### PR TITLE
台繁中 本地化 5/16更新

### DIFF
--- a/Langs/zh_tw.axaml
+++ b/Langs/zh_tw.axaml
@@ -302,7 +302,7 @@
     <sys:String x:Key="DecompressFailed">Natives解壓錯誤</sys:String>
     <sys:String x:Key="IncompleteArgument">不完整的啟動參數</sys:String>
     <sys:String x:Key="NoJava">未指定Java虛擬機</sys:String>
-    <sys:String x:Key="None">暫無程序</sys:String>
+    <sys:String x:Key="None">暫無</sys:String>
     <sys:String x:Key="OperationFailed">執行錯誤</sys:String>
 
     <sys:String x:Key="Duration">用時</sys:String>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the localization strings in the `Langs/zh_tw.axaml` file, specifically modifying the translation for a key.

### Detailed summary
- Changed the translation for the key `None` from "暫無程序" to "暫無".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->